### PR TITLE
Updated Matlab Dynamic loading of the java library

### DIFF
--- a/getChebiEntity.m
+++ b/getChebiEntity.m
@@ -13,7 +13,8 @@ function chebiEntity = getChebiEntity(id)
     end
 
     if ~found_libchebi
-        javaaddpath('libChEBIj-1.0.0.jar');
+	folder = which('libChEBIj-1.0.0.jar');
+        javaaddpath(folder);
     end
     
     chebiEntity = javaObject('uk.ac.manchester.libchebi.ChebiEntity', id);


### PR DESCRIPTION
In the current the java library has to be on the path to be properly loaded. This small change alters that behaviour so that it is sufficient, if the folder is on the MATLAB path in order for the library to be callable from other folders.
